### PR TITLE
Updated Verbose mode and implemented macOS build artefacts

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -17,7 +17,9 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 8.0.x
+
     - name: Install dependencies
       run: dotnet restore Subdominator.sln
+
     - name: Build
       run: dotnet build --configuration Release --no-restore Subdominator.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,9 @@ jobs:
         run:
           dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
 
-      - name: Publish
-        uses: softprops/action-gh-release@v0.1.15
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: "Release-${{ matrix.target }}/*${{ matrix.ext }}"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,15 @@ jobs:
       - name: Build
         run: |
           dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
-          mv "Release-${{ matrix.target }}/Subdominator" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}"
+          [ -f "Release-${{ matrix.target }}/Subdominator" ] && mv "Release-${{ matrix.target }}/Subdominator" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}"
+          [ -f "Release-${{ matrix.target }}/Subdominator.exe" ] && mv "Release-${{ matrix.target }}/Subdominator.exe" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}.exe"
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: "Release-${{ matrix.target }}/*${{ matrix.ext }}"
+          files: |
+            "Release-${{ matrix.target }}/custom_fingerprints.json"
+            "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,9 @@ jobs:
           release_name="Subdominator-${{ matrix.target }}"
           # Build everything
           dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
+          
       - name: Publish
-        uses: softprops/action-gh-release@v0.1.5
+        uses: softprops/action-gh-release@v0.1.15
         with:
           files: "Release-${{ matrix.target }}/*${{ matrix.ext }}"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            "Release-${{ matrix.target }}/custom_fingerprints.json"
-            "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}*"
+          files: "Release-${{ matrix.target }}/*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: "Create Releases"
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Build
+        shell: bash
         run: |
           dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
           [ -f "Release-${{ matrix.target }}/Subdominator" ] && mv "Release-${{ matrix.target }}/Subdominator" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,25 +30,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 8.0.x
 
       - name: Build
         run:
-          dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Subdominator-${{ matrix.target }}" -p:UseNativeAot=true
+          dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
 
       - name: Publish
         uses: softprops/action-gh-release@v0.1.15
         with:
-          files: "Subdominator-${{ matrix.target }}/*${{ matrix.ext }}"
+          files: "Release-${{ matrix.target }}/*${{ matrix.ext }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload dotnet test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: Subdominator-${{ matrix.target }}
-          # path: TestResults-${{ matrix.dotnet-version }}
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,7 @@ jobs:
         shell: bash
         run: |
           dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
-          [ -f "Release-${{ matrix.target }}/Subdominator" ] && mv "Release-${{ matrix.target }}/Subdominator" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}"
-          [ -f "Release-${{ matrix.target }}/Subdominator.exe" ] && mv "Release-${{ matrix.target }}/Subdominator.exe" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}.exe"
+          mv "Release-${{ matrix.target }}/Subdominator" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}" || mv "Release-${{ matrix.target }}/Subdominator.exe" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}.exe"
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             target: linux-x64
             ext: ''
           - kind: macos
-            os: ubuntu-latest
+            os: macos-latest
             target: osx-x64
             ext: ''
           - kind: windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   release:
     types: [published]
-    
+
 jobs:
   release:
     name: Release
@@ -27,23 +27,28 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
 
       - name: Build
-        shell: bash
-        run: |
-          release_name="Subdominator-${{ matrix.target }}"
-          # Build everything
-          dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
-          
+        run:
+          dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Subdominator-${{ matrix.target }}" -p:UseNativeAot=true
+
       - name: Publish
         uses: softprops/action-gh-release@v0.1.15
         with:
-          files: "Release-${{ matrix.target }}/*${{ matrix.ext }}"
+          files: "Subdominator-${{ matrix.target }}/*${{ matrix.ext }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload dotnet test results
+          uses: actions/upload-artifact@v4
+          with:
+            name: Subdominator-${{ matrix.target }}
+            # path: TestResults-${{ matrix.dotnet-version }}
+          # Use always() to always run this step to publish test results when there are test failures
+          if: ${{ always() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,9 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Build
-        run:
+        run: |
           dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
+          mv "Release-${{ matrix.target }}/Subdominator" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}"
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload dotnet test results
-          uses: actions/upload-artifact@v4
-          with:
-            name: Subdominator-${{ matrix.target }}
-            # path: TestResults-${{ matrix.dotnet-version }}
-          # Use always() to always run this step to publish test results when there are test failures
-          if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Subdominator-${{ matrix.target }}
+          # path: TestResults-${{ matrix.dotnet-version }}
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           dotnet publish Subdominator/Subdominator.csproj -r "${{ matrix.target }}" -c Release -o "Release-${{ matrix.target }}" -p:UseNativeAot=true
-          mv "Release-${{ matrix.target }}/Subdominator" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}" || mv "Release-${{ matrix.target }}/Subdominator.exe" "Release-${{ matrix.target }}/Subdominator-${{ matrix.kind }}.exe"
+          mv "Release-${{ matrix.target }}/Subdominator" "Release-${{ matrix.target }}/subdominator-${{ matrix.kind }}" || echo "Don't touch Subdominator.exe"
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             target: linux-x64
             ext: ''
           - kind: macos
-            os: macos
+            os: ubuntu-latest
             target: osx-x64
             ext: ''
           - kind: windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,15 @@ jobs:
     name: Release
     strategy:
       matrix:
-        kind: ['linux', 'windows']
+        kind: ['linux', 'macos', 'windows']
         include:
           - kind: linux
             os: ubuntu-latest
             target: linux-x64
+            ext: ''
+          - kind: macos
+            os: macos
+            target: osx-x64
             ext: ''
           - kind: windows
             os: windows-latest

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,12 +11,16 @@ Meet **Subdominator**, your new favourite CLI tool for detecting subdomain takeo
 ## Installing 🛠️
 To quickly, get up and running, you can download the latest release for [windows](https://github.com/Stratus-Security/Subdominator/releases/latest/download/Subdominator.exe) or [linux](https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-linux) or [macos](https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-macos).
 Alternatively, download it via CLI:
+### Windows
 ```base
-# Windows
 wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/Subdominator.exe
-# Linux
+```
+### Linux
+```base
 wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-linux
-# macOS
+```
+### macOS
+```base
 wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-macos
 ```
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,6 +3,13 @@
 
 # Subdominator 🚀
 
+> [!NOTE]
+> Please be aware this is a fork of the original Subdominator from Stratus-Security.
+> This fork has some updates: 🌟
+> - Verbose mode updated; Subdominator only prints extra information in verbose mode (it is silent by default)
+> - It's performance upgraded; HTTP retries are downscaled from 3 to 1 to boost performance
+> - Ready made binaries for [Windows, Linux and macOS](https://github.com/topscoder/Subdominator/releases/latest)
+
 ## Welcome to the Subdominator Club!
 Meet **Subdominator**, your new favourite CLI tool for detecting subdomain takeovers. It's designed to be fast, accurate, and dependable, offering [a significant improvement over other available tools](https://www.stratussecurity.com/post/the-ultimate-subdomain-takeover-tool).
 
@@ -12,26 +19,45 @@ Meet **Subdominator**, your new favourite CLI tool for detecting subdomain takeo
 To quickly, get up and running, you can download the latest release for [windows](https://github.com/topscoder/Subdominator/releases/latest/download/Subdominator.exe) or [linux](https://github.com/topscoder/Subdominator/releases/latest/download/subdominator-linux) or [macos](https://github.com/topscoder/Subdominator/releases/latest/download/subdominator-macos).
 Alternatively, download it via CLI:
 ### Windows
-```base
+```bash
 wget https://github.com/topscoder/Subdominator/releases/latest/download/Subdominator.exe
 ```
 ### Linux
-```base
+```bash
 wget https://github.com/topscoder/Subdominator/releases/latest/download/subdominator-linux
 ```
 ### macOS
-```base
+```bash
 wget https://github.com/topscoder/Subdominator/releases/latest/download/subdominator-macos
 ```
 
 ## Quick Start 🚦
 To quickly check a list of domains, simply run:
-```
+### Windows
+```bash
 Subdominator.exe -l subdomains.txt -o takeovers.txt
 ```
-Or to quickly check a single domain, run:
+### Linux
+```bash
+subdominator-linux -l subdomains.txt -o takeovers.txt
 ```
+### macOS
+```bash
+subdominator-macos -l subdomains.txt -o takeovers.txt
+```
+
+Or to quickly check a single domain, run:
+### Windows
+```bash
 Subdominator.exe -d sub.example.com
+```
+### Linux
+```bash
+subdominator-linux -d sub.example.com
+```
+### macOS
+```bash
+subdominator-macos -d sub.example.com
 ```
 
 ## Options 🎛️

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -9,14 +9,19 @@ Meet **Subdominator**, your new favourite CLI tool for detecting subdomain takeo
 🔍 Precision and speed are our goal. Subdominator delivers better results without the wait, see the benchmark and feature comparison below for details.
 
 ## Installing 🛠️
-To quickly, get up and running, you can download the latest release for [windows](https://github.com/Stratus-Security/Subdominator/releases/latest/download/Subdominator.exe) or [linux](https://github.com/Stratus-Security/Subdominator/releases/latest/download/Subdominator).
-Alternatively, download it via CLI (remove .exe for linux version):
+To quickly, get up and running, you can download the latest release for [windows](https://github.com/Stratus-Security/Subdominator/releases/latest/download/Subdominator.exe) or [linux](https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-linux) or [macos](https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-macos).
+Alternatively, download it via CLI:
 ```base
+# Windows
 wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/Subdominator.exe
+# Linux
+wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-linux
+# macOS
+wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-macos
 ```
 
 ## Quick Start 🚦
-To quickly check a list of domains, simply run: 
+To quickly check a list of domains, simply run:
 ```
 Subdominator.exe -l subdomains.txt -o takeovers.txt
 ```
@@ -51,9 +56,9 @@ The output format is as follows:
 For example, a vulnerable Azure CDN takeover will look like this:
 ```
 [Microsoft Azure] example.stratussecurity.com - CNAME: stratus-cdn-stg.azureedge.net
-``` 
+```
 
-If you use the verbose flag, it will print all domains checked. 
+If you use the verbose flag, it will print all domains checked.
 For example, this shows the same vulnerable domain and another non-vulnerable domain indicated by [-]:
 ```
 [Microsoft Azure] example.stratussecurity.com - CNAME: stratus-cdn-stg.azureedge.net
@@ -105,7 +110,7 @@ A benchmark was run across ~100,000 subdomains to compare performance with other
 ## Contributions
 Got a suggestion, fingerprint, or want to chip in? We're all ears! Open a PR or issue – this will keep subdominator on top! 😄
 
-## Fingerprints 
+## Fingerprints
 The fingerprints and services are dynamically pulled from the [CanITakeOverXYZ repo](https://github.com/EdOverflow/can-i-take-over-xyz) as a source of truth. To fill in the gaps and correct incorrect fingerprints, this tool also has its own [custom fingerprints list](https://github.com/Stratus-Security/Subdominator/blob/master/Subdominator/custom_fingerprints.json) which is used in conjunction.
 
 Below is the current list of services supported, to ignore edge cases use the `-eu` flag.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,5 @@
-![GitHub Actions CI](https://github.com/Stratus-Security/Subdominator/workflows/CI/badge.svg)
-![GitHub all releases](https://img.shields.io/github/downloads/Stratus-Security/Subdominator/total)
+![GitHub Actions CI](https://github.com/topscoder/Subdominator/workflows/CI/badge.svg)
+![GitHub all releases](https://img.shields.io/github/downloads/topscoder/Subdominator/total)
 
 # Subdominator 🚀
 
@@ -9,19 +9,19 @@ Meet **Subdominator**, your new favourite CLI tool for detecting subdomain takeo
 🔍 Precision and speed are our goal. Subdominator delivers better results without the wait, see the benchmark and feature comparison below for details.
 
 ## Installing 🛠️
-To quickly, get up and running, you can download the latest release for [windows](https://github.com/Stratus-Security/Subdominator/releases/latest/download/Subdominator.exe) or [linux](https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-linux) or [macos](https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-macos).
+To quickly, get up and running, you can download the latest release for [windows](https://github.com/topscoder/Subdominator/releases/latest/download/Subdominator.exe) or [linux](https://github.com/topscoder/Subdominator/releases/latest/download/subdominator-linux) or [macos](https://github.com/topscoder/Subdominator/releases/latest/download/subdominator-macos).
 Alternatively, download it via CLI:
 ### Windows
 ```base
-wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/Subdominator.exe
+wget https://github.com/topscoder/Subdominator/releases/latest/download/Subdominator.exe
 ```
 ### Linux
 ```base
-wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-linux
+wget https://github.com/topscoder/Subdominator/releases/latest/download/subdominator-linux
 ```
 ### macOS
 ```base
-wget https://github.com/Stratus-Security/Subdominator/releases/latest/download/subdominator-macos
+wget https://github.com/topscoder/Subdominator/releases/latest/download/subdominator-macos
 ```
 
 ## Quick Start 🚦
@@ -77,7 +77,7 @@ These domains have been validated to be vulnerable with the services directly, n
 
 ## Demo
 The tool running across 1000 passively gathered subdomains:
-![Demo](https://raw.githubusercontent.com/Stratus-Security/Subdominator/master/Demo.gif)
+![Demo](https://raw.githubusercontent.com/topscoder/Subdominator/master/Demo.gif)
 
 ## Benchmark 📊
 A benchmark was run across ~100,000 subdomains to compare performance with other popular tools
@@ -115,7 +115,7 @@ A benchmark was run across ~100,000 subdomains to compare performance with other
 Got a suggestion, fingerprint, or want to chip in? We're all ears! Open a PR or issue – this will keep subdominator on top! 😄
 
 ## Fingerprints
-The fingerprints and services are dynamically pulled from the [CanITakeOverXYZ repo](https://github.com/EdOverflow/can-i-take-over-xyz) as a source of truth. To fill in the gaps and correct incorrect fingerprints, this tool also has its own [custom fingerprints list](https://github.com/Stratus-Security/Subdominator/blob/master/Subdominator/custom_fingerprints.json) which is used in conjunction.
+The fingerprints and services are dynamically pulled from the [CanITakeOverXYZ repo](https://github.com/EdOverflow/can-i-take-over-xyz) as a source of truth. To fill in the gaps and correct incorrect fingerprints, this tool also has its own [custom fingerprints list](https://github.com/topscoder/Subdominator/blob/master/Subdominator/custom_fingerprints.json) which is used in conjunction.
 
 Below is the current list of services supported, to ignore edge cases use the `-eu` flag.
 | Service | Status |

--- a/Subdominator/Program.cs
+++ b/Subdominator/Program.cs
@@ -192,7 +192,7 @@ public class Program
 
     static IEnumerable<string> FilterAndNormalizeDomains(List<string> domains, bool verbose = false)
     {
-        var domainParser = new DomainParser(new WebTldRuleProvider("https://raw.githubusercontent.com/Stratus-Security/Subdominator/master/Subdominator/public_suffix_list.dat", new FileCacheProvider(cacheTimeToLive: TimeSpan.FromSeconds(0))));
+        var domainParser = new DomainParser(new WebTldRuleProvider("https://raw.githubusercontent.com/topscoder/Subdominator/master/Subdominator/public_suffix_list.dat", new FileCacheProvider(cacheTimeToLive: TimeSpan.FromSeconds(0))));
 
         // Normalize domains and check validity
         var normalizedDomains = domains

--- a/Subdominator/Program.cs
+++ b/Subdominator/Program.cs
@@ -117,11 +117,10 @@ public class Program
 
         // Define maximum concurrent tasks
         int maxConcurrentTasks = o.Threads;
-        bool verbose = o.Verbose;
         var vulnerableCount = 0;
 
         // Pre-check domains passed in and filter any that are invalid
-        var domains = FilterAndNormalizeDomains(rawDomains);
+        var domains = FilterAndNormalizeDomains(rawDomains, o.Verbose);
 
         // Pre-load fingerprints to memory
         var hijackChecker = new SubdomainHijack();
@@ -138,7 +137,7 @@ public class Program
         var updateTask = PeriodicUpdateAsync(updateInterval, () =>
         {
             // Skip the first print since it's 0 anyway
-            if (completedTasks != 0)
+            if (o.Verbose == true && completedTasks != 0)
             {
                 var elapsed = stopwatch.Elapsed;
                 var rate = completedTasks / elapsed.TotalSeconds;
@@ -148,7 +147,7 @@ public class Program
 
         await Parallel.ForEachAsync(domains, new ParallelOptions { MaxDegreeOfParallelism = maxConcurrentTasks }, async (domain, cancellationToken) =>
         {
-            var isVulnerable = await CheckAndLogDomain(hijackChecker, domain, o.OutputFile, o.Validate, verbose);
+            var isVulnerable = await CheckAndLogDomain(hijackChecker, domain, o.OutputFile, o.Validate, o.Verbose);
             if(isVulnerable)
             {
                 Interlocked.Increment(ref vulnerableCount);
@@ -161,10 +160,12 @@ public class Program
         await updateTask; // Ensure the update task completes before finishing the program
 
         // One last output for clarity
-        var elapsed = stopwatch.Elapsed;
-        var rate = completedTasks / elapsed.TotalSeconds;
-        Console.WriteLine($"{completedTasks}/{domains.Count()} domains processed. Average rate: {rate:F2} domains/sec");
-        Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:N2}s! Subdominator found {vulnerableCount} vulnerable domains.");
+        if (o.Verbose == true) {
+            var elapsed = stopwatch.Elapsed;
+            var rate = completedTasks / elapsed.TotalSeconds;
+            Console.WriteLine($"{completedTasks}/{domains.Count()} domains processed. Average rate: {rate:F2} domains/sec");
+            Console.WriteLine($"Done in {stopwatch.Elapsed.TotalSeconds:N2}s! Subdominator found {vulnerableCount} vulnerable domains.");
+        }
 
         // Exit non-zero if we have a takeover, for the DevOps folks
         if (vulnerableCount > 0)
@@ -189,7 +190,7 @@ public class Program
         }
     }
 
-    static IEnumerable<string> FilterAndNormalizeDomains(List<string> domains)
+    static IEnumerable<string> FilterAndNormalizeDomains(List<string> domains, bool verbose = false)
     {
         var domainParser = new DomainParser(new WebTldRuleProvider("https://raw.githubusercontent.com/Stratus-Security/Subdominator/master/Subdominator/public_suffix_list.dat", new FileCacheProvider(cacheTimeToLive: TimeSpan.FromSeconds(0))));
 
@@ -200,12 +201,15 @@ public class Program
             .ToList();
 
         // Count and report removed domains
-        var removedDomains = normalizedDomains.Count(d => !d.IsValid);
-        if (removedDomains > 0)
+        if (verbose == true)
         {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"Removed {removedDomains} invalid domains.");
-            Console.ResetColor();
+            var removedDomains = normalizedDomains.Count(d => !d.IsValid);
+            if (removedDomains > 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"Removed {removedDomains} invalid domains.");
+                Console.ResetColor();
+            }
         }
 
         // Return only valid domains

--- a/Subdominator/SubdomainHijack.cs
+++ b/Subdominator/SubdomainHijack.cs
@@ -46,7 +46,7 @@ public class SubdomainHijack
 
     // Extra cnames
     private Dictionary<string, List<string>> _cnameOverrides = new()
-    {        
+    {
         { "Acquia", new(){ "acquia-test.co" } },
         { "Campaign Monitor", new(){ "createsend.com", "name.createsend.com" } },
         { "Canny", new(){ "cname.canny.io" } },
@@ -164,7 +164,7 @@ public class SubdomainHijack
                     // Save the file locally for future use
                     await File.WriteAllTextAsync(filePath, fingerprintsData);
                 }
-                
+
                 // We also have a custom fingerprints file to enhance coverage but still allow auto-updates from can-i-take-over-xyz
                 if (!update && File.Exists(customFilePath))
                 {
@@ -234,7 +234,7 @@ public class SubdomainHijack
                     {
                         fingerprint.Nxdomain = _nxDomainOverride[fingerprint.Service];
                     }
-                    
+
                     if (_aOverrides.ContainsKey(fingerprint.Service))
                     {
                         fingerprint.ARecords.AddRange(_aOverrides[fingerprint.Service]);
@@ -259,7 +259,7 @@ public class SubdomainHijack
                 // Now iterate custom fingerprints. The custom list is used for completeness, so it should not override the original
                 foreach(var fingerprint in customFingerprints)
                 {
-                    if (fingerprint.Status.ToLower() != "not vulnerable" && 
+                    if (fingerprint.Status.ToLower() != "not vulnerable" &&
                         !_fingerprints.Any(f => f.Service.ToLower() == fingerprint.Service.ToLower())
                     )
                     {
@@ -404,7 +404,7 @@ public class SubdomainHijack
         }
 
         // Only check fingerprints if we have a (partial) match
-        if (isCnameMatch || isAMatch || isAaaaMatch) 
+        if (isCnameMatch || isAMatch || isAaaaMatch)
         {
             var response = await HttpGet(domain, fingerprint.HttpStatus >= 300 && fingerprint.HttpStatus < 400);
             string responseBody = "";
@@ -457,7 +457,7 @@ public class SubdomainHijack
 
     private async Task ResolveDns(string domain, CnameResolutionResult result, HashSet<string> visitedCnames)
     {
-        const int maxRetries = 3; // Maximum number of retries
+        const int maxRetries = 1; // Maximum number of retries
         int retryCount = 0;
 
         while (retryCount < maxRetries)
@@ -650,7 +650,7 @@ public class SubdomainHijack
         {
             return await client.GetAsync($"https://{domain}");
         }
-        catch (HttpRequestException ex) when (ex.Message.Contains("No such host is known.")) 
+        catch (HttpRequestException ex) when (ex.Message.Contains("No such host is known."))
         {
             // We could just skip HTTP requests when we detect NXDOMAIN responses but there's edge cases.
             // For example, there could be an A record that points to an IP on a vulnerable domain

--- a/Subdominator/SubdomainHijack.cs
+++ b/Subdominator/SubdomainHijack.cs
@@ -135,7 +135,7 @@ public class SubdomainHijack
 
         _dnsClient = new LookupClient();
 
-        _domainParser = new DomainParser(new WebTldRuleProvider("https://raw.githubusercontent.com/Stratus-Security/Subdominator/master/Subdominator/public_suffix_list.dat", new FileCacheProvider(cacheTimeToLive: TimeSpan.FromSeconds(0))));
+        _domainParser = new DomainParser(new WebTldRuleProvider("https://raw.githubusercontent.com/topscoder/Subdominator/master/Subdominator/public_suffix_list.dat", new FileCacheProvider(cacheTimeToLive: TimeSpan.FromSeconds(0))));
     }
 
     public async Task<IEnumerable<Fingerprint>> GetFingerprintsAsync(bool excludeUnlikely, bool update = false)
@@ -172,7 +172,7 @@ public class SubdomainHijack
                 }
                 else
                 {
-                    var customFingerprintsUrl = "https://raw.githubusercontent.com/Stratus-Security/Subdominator/master/Subdominator/custom_fingerprints.json";
+                    var customFingerprintsUrl = "https://raw.githubusercontent.com/topscoder/Subdominator/master/Subdominator/custom_fingerprints.json";
                     customFingerprintsData = await _httpClient.GetStringAsync(customFingerprintsUrl);
 
                     await File.WriteAllTextAsync(customFilePath, customFingerprintsData);


### PR DESCRIPTION
Hi, I'm a fan of Subdominator. As I'm a macOS user, I've updated two parts:

1) Verbose mode; I've changed Subdominator to output less information in default behaviour and moved it to (the already existing) verbose mode. This, so you can use Subdominator in a command chain and have it only output data if it found a vulnerable subdomain. For example: `$ subdominator-macos -d target.com | notify`

2) macOS Artefact; I've updated the release GitHub Action to also build a macOS version upon release. For this I've changed the naming of the Linux binary, but left Subdominator.exe naming in tact. It's now:
- Subdominator.exe
- subdominator-linux
- subdominator-macos

To show the result of the build artefacts, I've created a new release 1.66 for testing purposes on https://github.com/topscoder/Subdominator/releases

Would love to see these updates being migrated. I'm here to discuss and help.