### PR TITLE
Fix thread value validation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -30,7 +30,7 @@ Subdominator -d sub.example.com
 -d, --domain <domain>    A single domain to check
 -l, --list <list>        A list of domains to check (line delimited)
 -o, --output <output>    Output subdomains to a file
--t, --threads <threads>  Number of domains to check at once [default: 50]
+-t, --threads <threads>  Number of domains to check at once; values \<= 0 use the default [default: 50]
 -v, --verbose            Print extra information
 -q, --quiet              Quiet mode: Only print found results
 -eu, --exclude-unlikely  Exclude unlikely (edge-case) fingerprints

--- a/Subdominator.Tests/ThreadValidationTests.cs
+++ b/Subdominator.Tests/ThreadValidationTests.cs
@@ -1,0 +1,15 @@
+using Subdominator;
+
+namespace Subdominator.Tests;
+
+[TestClass]
+public class ThreadValidationTests
+{
+    [TestMethod]
+    public void InvalidThreadValuesDefaultTo50()
+    {
+        Assert.AreEqual(50, Program.ValidateThreadCount(0));
+        Assert.AreEqual(50, Program.ValidateThreadCount(-5));
+        Assert.AreEqual(10, Program.ValidateThreadCount(10));
+    }
+}

--- a/Subdominator/Program.cs
+++ b/Subdominator/Program.cs
@@ -29,7 +29,7 @@ public class Program
             new Option<string>(["-d", "--domain"], "A single domain to check"),
             new Option<string>(["-l", "--list"], "A list of domains to check (line delimited)") { Name = "DomainsFile" }, 
             new Option<string>(["-o", "--output"], "Output subdomains to a file") { Name = "OutputFile" },
-            new Option<int>(["-t", "--threads"], () => 50, "Number of domains to check at once"),
+            new Option<int>(["-t", "--threads"], () => 50, "Number of domains to check at once (0 or less uses default of 50)"),
             new Option<bool>(["-v", "--verbose"], "Print extra information"),
             new Option<bool>(["-q", "--quiet"], "Quiet mode: Only print found results"),
             new Option<string>(["-c", "--csv"], "Heading or column index to parse for CSV file. Forces -l to read as CSV instead of line-delimited") { Name = "CsvHeading" },
@@ -120,7 +120,7 @@ public class Program
         }
 
         // Define maximum concurrent tasks
-        int maxConcurrentTasks = o.Threads;
+        int maxConcurrentTasks = ValidateThreadCount(o.Threads);
         var vulnerableCount = 0;
 
         // Pre-check domains passed in and filter any that are invalid
@@ -295,5 +295,10 @@ public class Program
             Console.WriteLine(ex.ToString());
         }
         return isFound;
+    }
+
+    public static int ValidateThreadCount(int threads)
+    {
+        return threads > 0 ? threads : 50;
     }
 }


### PR DESCRIPTION
## Summary
- handle non-positive thread values before running threads
- document fallback to default thread count
- test thread validation logic

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_683ff833908c832fa70476b61be94e52