### PR TITLE
Fix exclude-unlikely handling

### DIFF
--- a/Subdominator.Tests/FingerprintTests.cs
+++ b/Subdominator.Tests/FingerprintTests.cs
@@ -67,4 +67,16 @@ public class FingerprintTests
 
         return $"{subdomain}.{baseCname}";
     }
+
+    [TestMethod]
+    public async Task ShouldExcludeEdgeCaseFingerprints()
+    {
+        var hijack = new SubdomainHijack();
+        var allFingerprints = await hijack.GetFingerprintsAsync(false);
+        Assert.IsTrue(allFingerprints.Any(f => f.Status.ToLower() == "edge case"));
+
+        hijack = new SubdomainHijack();
+        var filteredFingerprints = await hijack.GetFingerprintsAsync(true);
+        Assert.IsFalse(filteredFingerprints.Any(f => f.Status.ToLower() == "edge case"));
+    }
 }

--- a/Subdominator/Program.cs
+++ b/Subdominator/Program.cs
@@ -160,7 +160,7 @@ public class Program
 
         await Parallel.ForEachAsync(domains, new ParallelOptions { MaxDegreeOfParallelism = maxConcurrentTasks }, async (domain, cancellationToken) =>
         {
-            var isVulnerable = await CheckAndLogDomain(hijackChecker, domain, o.Validate, o.Verbose, o.Quiet);
+            var isVulnerable = await CheckAndLogDomain(hijackChecker, domain, o.Validate, o.Verbose, o.Quiet, o.ExcludeUnlikely);
             if(isVulnerable)
             {
                 Interlocked.Increment(ref vulnerableCount);
@@ -237,12 +237,12 @@ public class Program
         return normalizedDomains.Where(d => d.IsValid).Select(d => d.Original);
     }
 
-    static async Task<bool> CheckAndLogDomain(SubdomainHijack hijackChecker, string domain, bool validateResults, bool verbose, bool quiet)
+    static async Task<bool> CheckAndLogDomain(SubdomainHijack hijackChecker, string domain, bool validateResults, bool verbose, bool quiet, bool excludeUnlikely)
     {
         bool isFound = false;
         try
         {
-            var result = await hijackChecker.IsDomainVulnerable(domain, validateResults);
+            var result = await hijackChecker.IsDomainVulnerable(domain, validateResults, excludeUnlikely);
             if (result.IsVulnerable || verbose)
             {
                 if (result.IsVulnerable)

--- a/Subdominator/SubdomainHijack.cs
+++ b/Subdominator/SubdomainHijack.cs
@@ -306,9 +306,9 @@ public class SubdomainHijack
         return _fingerprints;
     }
 
-    public async Task<TakeoverResult> IsDomainVulnerable(string domain, bool validateResults, bool update = false)
+    public async Task<TakeoverResult> IsDomainVulnerable(string domain, bool validateResults, bool excludeUnlikely = false, bool update = false)
     {
-        var fingerprints = await GetFingerprintsAsync(update);
+        var fingerprints = await GetFingerprintsAsync(excludeUnlikely: excludeUnlikely, update: update);
 
         // DNS Lookup
         var subdomainDns = await GetDnsForSubdomain(domain);


### PR DESCRIPTION
## Summary
- wire exclude-unlikely parameter through IsDomainVulnerable
- pass flag from Program when checking each domain
- add regression test for filtering edge-case fingerprints

## Testing
- `dotnet test` *(fails: Unable to get IAM security credentials / InteractiveBrowserCredential authentication failed)*

------
https://chatgpt.com/codex/tasks/task_e_683ff83ae44c832f8b09e6274ba0f206